### PR TITLE
Dont fail when removing a pidfile

### DIFF
--- a/bin/autorunner
+++ b/bin/autorunner
@@ -245,7 +245,7 @@ execute() {
 					logger "err" "(${bin}) could not kill pid: '${pid}'"
 				else
 					# Remove pidfile
-					rm "${pidfile}"
+					rm "${pidfile}" || true
 					# Log
 					logger "info" "(${bin}) killed pid: '${pid}'"
 					# Notify


### PR DESCRIPTION
Fixes a bug when it tried to remove a pidfile and it didnt exist. In the previous behaviour the program just terminated unsuccessfully. This has been fixed now.